### PR TITLE
Fix load error of 'pathname' library

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,3 +1,8 @@
+== 0.1.1 (July 7, 2021)
+
+=== Bug Fixes
+* Fix load error of 'pathname' library https://github.com/9sako6/zoi/pull/3[#3]
+
 == 0.1.0 (July 7, 2021)
 
 === Enhancements

--- a/lib/zoi/cli.rb
+++ b/lib/zoi/cli.rb
@@ -3,6 +3,7 @@
 require 'fileutils'
 require 'find'
 require 'open3'
+require 'pathname'
 require 'thor'
 
 module Zoi

--- a/lib/zoi/version.rb
+++ b/lib/zoi/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Zoi
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end


### PR DESCRIPTION
This PR fixes the following error.

```
$ EDITOR=code zoi open hofaifasd.rb
Traceback (most recent call last):
        9: from /Users/9sako6/.rbenv/versions/2.7.1/bin/zoi:23:in `<main>'
        8: from /Users/9sako6/.rbenv/versions/2.7.1/bin/zoi:23:in `load'
        7: from /Users/9sako6/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/zoi-0.1.0/exe/zoi:8:in `<top (required)>'
        6: from /Users/9sako6/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/thor-1.1.0/lib/thor/base.rb:485:in `start'
        5: from /Users/9sako6/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/thor-1.1.0/lib/thor.rb:392:in `dispatch'
        4: from /Users/9sako6/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/thor-1.1.0/lib/thor/invocation.rb:127:in `invoke_command'
        3: from /Users/9sako6/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/thor-1.1.0/lib/thor/command.rb:27:in `run'
        2: from /Users/9sako6/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/zoi-0.1.0/lib/zoi/cli.rb:23:in `open'
        1: from /Users/9sako6/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/zoi-0.1.0/lib/zoi/cli.rb:44:in `create_file'
/Users/9sako6/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/zoi-0.1.0/lib/zoi/cli.rb:60:in `root_path': undefined method `Pathname' for #<Zoi::CLI:0x00007fbdb71ff4d8> (NoMethodError)
```