### PR TITLE
Add `root` command

### DIFF
--- a/lib/zoi/cli.rb
+++ b/lib/zoi/cli.rb
@@ -36,6 +36,15 @@ module Zoi
       puts(Find.find(root_path).select { |path| only_directory ? File.directory?(path) : File.file?(path) })
     end
 
+    desc 'root', 'Print zoi root directory.'
+    def root_command
+      puts root_path
+    end
+
+    # NOTE: Resolve the following error.
+    #       `"root" is a Thor reserved word and cannot be defined as command`
+    map 'root' => 'root_command'
+
     no_tasks do
       def editor
         @editor ||= ENV['EDITOR']

--- a/test/zoi_test.rb
+++ b/test/zoi_test.rb
@@ -13,7 +13,9 @@ class TestZoi < MiniTest::Unit::TestCase
 
     FileUtils.mkdir_p(@tmp_path)
 
-    Zoi::CLI.any_instance.stubs(:root_path).returns(Pathname(Dir.pwd).join(@tmp_path).join(Zoi::ROOT_DIR_NAME).to_s)
+    @root_path = Pathname(Dir.pwd).join(@tmp_path).join(Zoi::ROOT_DIR_NAME).to_s
+
+    Zoi::CLI.any_instance.stubs(:root_path).returns(@root_path)
 
     $stdout = File.open('/dev/null', 'w')
   end
@@ -52,5 +54,11 @@ class TestZoi < MiniTest::Unit::TestCase
     files_list = File.open(output_path, 'r', &:read).split("\n")
 
     assert_equal file_paths.map { |file_path| "#{Zoi::CLI.new.root_path}/#{file_path}" }.sort, files_list.sort
+  end
+
+  def test_root
+    assert_output("#{@root_path}\n") do
+      Zoi::CLI.start(['root'])
+    end
   end
 end


### PR DESCRIPTION
`root` command prints zoi root directory.

fix #7