### PR TITLE
Add a config file to specify the editor type

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,3 +1,20 @@
+== 0.1.4 (January 6, 2022)
+
+=== Enhancements
+* Add a configuration file, __~/.zoirc.json__ https://github.com/9sako6/zoi/pull/17[#17]
+** You can optionally save the settings used by zoi to a configuration file, __~/.zoirc.json__. +
+The type of editor used by zoi can be specified in the __~/.zoirc.json__ file. +
+The following is the example of the __~/.zoirc.json__ file.
++
+[source,json]
+----
+{
+  "editor": "code"
+}
+----
++
+In that case, there is no need to pass the `EDITOR` environment variable at runtime.
+
 == 0.1.3 (September 15, 2021)
 
 === Enhancements

--- a/README.adoc
+++ b/README.adoc
@@ -53,6 +53,23 @@ help::
 
     gem install zoi
 
+== CONFIGURATION
+
+You can optionally save the settings used by zoi to a configuration file, __~/.zoirc.json__.
+
+The type of editor used by zoi can be specified in the __~/.zoirc.json__ file.
+
+The following is the example of the __~/.zoirc.json__ file.
+
+[source,json]
+----
+{
+  "editor": "code"
+}
+----
+
+In that case, there is no need to pass the `EDITOR` environment variable at runtime.
+
 == EXAMPLES
 
 * Change directories

--- a/lib/zoi/cli.rb
+++ b/lib/zoi/cli.rb
@@ -3,12 +3,14 @@
 require "date"
 require "fileutils"
 require "find"
+require "json"
 require "open3"
 require "pathname"
 require "thor"
 
 module Zoi
   ROOT_DIR_NAME = "zoi"
+  CONFIG_FILE_NAME = ".zoirc.json"
 
   class CLI < Thor
     desc "create <filepath>", "Create a new file under zoi root directory."
@@ -62,6 +64,10 @@ module Zoi
 
     no_tasks do
       def editor
+        if File.exist?(config_file_path)
+          load_envs_from_config_file
+        end
+
         ENV["EDITOR"]
       end
 
@@ -83,6 +89,18 @@ module Zoi
 
       def root_path
         @root_path ||= Pathname(Dir.home).join(ROOT_DIR_NAME).to_s
+      end
+
+      def config_file_path
+        @config_file_path ||= Pathname(Dir.home).join(CONFIG_FILE_NAME).to_s
+      end
+
+      def config_json
+        @config_json ||= JSON.parse(File.open(config_file_path, "r", &:read))
+      end
+
+      def load_envs_from_config_file
+        ENV["EDITOR"] = config_json["editor"] unless ENV["EDITOR"]
       end
     end
   end

--- a/lib/zoi/version.rb
+++ b/lib/zoi/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Zoi
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end


### PR DESCRIPTION
We can specify the editor to open files in `~/.zoirc.json` file.