### PR TITLE
Suppress thor warning

### DIFF
--- a/exe/zoi
+++ b/exe/zoi
@@ -5,4 +5,6 @@ require "zoi"
 
 args = File.pipe?($stdin) ? ARGV + $stdin.gets.chomp.split : ARGV
 
+ENV["THOR_SILENCE_DEPRECATION"] = "true"
+
 Zoi::CLI.start(args)


### PR DESCRIPTION
This PR suppresses the following warning when an error is raised.

```
Deprecation warning: Thor exit with status 0 on errors. To keep this behavior, you must define `exit_on_failure?` in `Zoi::CLI`
You can silence deprecations warning by setting the environment variable THOR_SILENCE_DEPRECATION.
```